### PR TITLE
DB connection state

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,11 +1,18 @@
-use anyhow::{Context, Result};
-use std::env;
+use anyhow::{Context, Result, anyhow};
+use std::{
+    any::type_name,
+    env::{self, VarError},
+    fmt::Display,
+    str::FromStr,
+};
 
 pub struct AppConfig {
     pub database_url: String,
     pub frontend_url: String,
     pub bind_addr: String,
     pub jwt_secret: String,
+    pub max_pool_connections: u32,
+    pub db_conn_timeout_secs: u64,
 }
 
 impl AppConfig {
@@ -15,11 +22,44 @@ impl AppConfig {
         #[cfg(debug_assertions)]
         dotenvy::dotenv().context("failed to load .env file")?;
 
-        let database_url = env::var("DATABASE_URL").context("failed to load DATABASE_URL")?;
-        let frontend_url = env::var("FRONTEND_URL").context("failed to load FRONTEND_URL")?;
-        let bind_addr = env::var("BIND_ADDR").context("failed to load BIND_ADDR")?;
-        let jwt_secret = env::var("JWT_SECRET").context("failed to load JWT_SECRET")?;
+        Ok(Self {
+            // Definitely different in dev and prod?
+            // -> No defaults, must be set as environment variables
+            database_url: Self::get_env("DATABASE_URL")?,
+            frontend_url: Self::get_env("FRONTEND_URL")?,
+            bind_addr: Self::get_env("BIND_ADDR")?,
+            jwt_secret: Self::get_env("JWT_SECRET")?,
 
-        Ok(Self { database_url, frontend_url, bind_addr, jwt_secret })
+            // Possibly the same in dev and prod?
+            // -> Hardcoded defaults that can be overridden with environment variables
+            max_pool_connections: Self::get_env_or_default(10, "MAX_POOL_CONNECTIONS")?,
+            db_conn_timeout_secs: Self::get_env_or_default(15, "DB_CONN_TIMEOUT_SECS")?,
+        })
+    }
+
+    fn get_env(key: &'static str) -> Result<String> {
+        env::var(key).with_context(|| format!("failed to load environment variable {key}"))
+    }
+
+    fn get_env_or_default<T>(default: T, key: &'static str) -> Result<T>
+    where
+        T: FromStr + Display,
+        T::Err: Send + Sync + 'static + std::error::Error,
+    {
+        match env::var(key) {
+            Err(VarError::NotUnicode(_)) => Err(anyhow!(
+                "environment variable {key} was present but not valid Unicode"
+            )),
+            Err(VarError::NotPresent) => {
+                println!("environment variable {key} not found, using {default}");
+                Ok(default)
+            }
+            Ok(val) => val.parse().with_context(|| {
+                format!(
+                    "environment variable {key} was present but could not be parsed as {}",
+                    type_name::<T>()
+                )
+            }),
+        }
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -24,7 +24,7 @@ use tokio::net::TcpListener;
 #[tokio::main]
 async fn main() -> Result<()> {
     let config = AppConfig::load()?;
-    let state = AppState::init(&config.database_url, config.jwt_secret).await?;
+    let state = AppState::init(&config).await?;
     let app = router::build(state, &config.frontend_url)?;
     let listener = TcpListener::bind(&config.bind_addr).await?;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -18,20 +18,13 @@ mod test_utils;
 use crate::api::router;
 use anyhow::Result;
 use config::AppConfig;
-use sqlx::postgres::PgPoolOptions;
 use state::AppState;
 use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let config = AppConfig::load()?;
-
-    let pool = PgPoolOptions::new()
-        .max_connections(10)
-        .connect(&config.database_url)
-        .await?;
-
-    let state = AppState::build(pool, config.jwt_secret);
+    let state = AppState::init(&config.database_url, config.jwt_secret).await?;
     let app = router::build(state, &config.frontend_url)?;
     let listener = TcpListener::bind(&config.bind_addr).await?;
 

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -27,7 +27,9 @@ pub struct AppState {
 }
 
 impl AppState {
-    /// Wires together the repository and service layers for use as `State` in handlers/middleware.
+    /// Wires together concrete infrastructure implementations (including the database connection),
+    /// domain services, application services, and read models to be accessed as `State` in the
+    /// API layer.
     pub async fn init(config: &AppConfig) -> Result<Self> {
         let pool = PgPoolOptions::new()
             .max_connections(config.max_pool_connections)

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -47,13 +47,11 @@ impl AppState {
             pool.clone(),
             PgUserRepo,
             PgFriendshipRepo,
-        )) as Arc<dyn MutateFriendshipByUsername>;
+        ));
 
-        let post_svc = Arc::new(PostDomainSvc::new(pool.clone(), PgPostRepo)) as Arc<dyn PostSvc>;
-
-        let social_read = Arc::new(PgSocialRead::new(pool.clone())) as Arc<dyn SocialRead>;
-        let post_with_author_read =
-            Arc::new(PgPostWithAuthorRead::new(pool)) as Arc<dyn PostWithAuthorRead>;
+        let post_svc = Arc::new(PostDomainSvc::new(pool.clone(), PgPostRepo));
+        let social_read = Arc::new(PgSocialRead::new(pool.clone()));
+        let post_with_author_read = Arc::new(PgPostWithAuthorRead::new(pool));
 
         Self { auth, mutate_friendship_by_username, post_svc, social_read, post_with_author_read }
     }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -14,7 +14,7 @@ use crate::{
 use anyhow::Result;
 use axum::extract::FromRef;
 use sqlx::{PgPool, postgres::PgPoolOptions};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 #[derive(Clone, FromRef)]
 pub struct AppState {
@@ -30,6 +30,7 @@ impl AppState {
     pub async fn init(db_url: &str, jwt_secret: String) -> Result<Self> {
         let pool = PgPoolOptions::new()
             .max_connections(10)
+            .acquire_timeout(Duration::from_secs(15))
             .connect(db_url)
             .await?;
 


### PR DESCRIPTION
Resolves #15 

This PR makes several relatively minor changes to the initialization of the database connection in the app state. Taken directly from #15, it achieves the following: 

- Move the `PgPoolOptions` setup from main to an `init` function of `AppState`. 
- Remove the unnecessary casts in the `AppState` setup logic.
- Update the doc comment for setting up `AppState`.
- Reduce the connection acquisition wait time from the default 30 seconds to 15 seconds (this can be further shortened or otherwise reconsidered later).

The PR also allows the maximum number of pool connections and the number of seconds the database connection waits to be optionally overridden with environment variables `MAX_POOL_CONNECTIONS` and `DB_CONN_TIMEOUT_SECS`. If not provided, the current defaults are 10 and 15, respectively. 