### PR TITLE
Automate migration generation with Atlas

### DIFF
--- a/backend/justfile
+++ b/backend/justfile
@@ -1,47 +1,73 @@
 ####################################################################################################
-# Dev DB container
-# Requires the Docker CLI and a running VM such as Docker Desktop or Colima
+# Settings/config
 ####################################################################################################
 
-# Initialize DB
-db-up:
-	docker compose -p spur up -d
+# Load a .env file if present
+set dotenv-load := true
 
-# Stop services and remove volumes (delete data)
-db-rm:
-	docker compose down -v
+####################################################################################################
+# Dev DB container/volume
+#
+# Requires the Docker CLI and a running VM such as Docker Desktop or Colima.
+####################################################################################################
 
-# Start the dev DB container
+docker-project := "spur"
+docker-volume := "postgres_data"
+docker-container := "spur_dev"
+
+# Start the dev DB container (also the default recipe)
 db-start:
-	docker start spur_dev
+	docker start {{docker-container}}
 
 # Stop the dev DB container
 db-stop:
-	docker stop spur_dev
+	docker stop {{docker-container}}
+
+# Initialize the dev DB container and volume
+db-up:
+	docker compose -p {{docker-project}} up -d
+
+# Remove the container and named Docker volume (persistent dev data)
+[confirm("Are you sure you want to remove the dev DB and all of its data?")]
+db-rm: db-stop
+	docker rm {{docker-container}}
+	docker volume rm {{docker-project}}_{{docker-volume}}
 
 ####################################################################################################
 # Migrations
 #
-# `sqlx` commands require the SQLx CLI with the feature flag for Postgres. TLS is not required to
-# use the local development database in Docker. Therefore, the minimal sqlx-cli installation
-# required for this project is: `cargo install sqlx-cli --no-default-features --features postgres`
+# Requires the Atlas CLI (https://atlasgo.io/getting-started#installation).
+# Recipes that use an ephemeral DB require the VM for Docker to be running.
+# Recipes that use the dev DB URL require the dev DB container to be running.
 ####################################################################################################
 
-# Create a new migration
+# A URL to pass to Atlas so that it can create an ephemeral DB to work in
+ephemeral-pg := "docker://postgres/17/dev"
+
+# The master schema to be edited by hand and diffed by Atlas
+schema-file := "file://schema.sql"
+
+# Recompute `atlas.sum` after manual changes
+mg-hash:
+	atlas migrate hash
+
+# Validate all migrations
+mg-validate:
+	atlas migrate validate --dev-url {{ephemeral-pg}}
+
+# Generate a new migration file by diffing the schema
 migration name:
-	sqlx migrate add {{name}}
+	atlas migrate diff {{name}} --to {{schema-file}} --dev-url {{ephemeral-pg}}
+
+# Preview new migrations to be run
+mg-preview: mg-validate
+	atlas migrate status --url $DATABASE_URL
+	atlas migrate apply --dry-run --url $DATABASE_URL
 
 # Run pending migrations
-migrate:
-	sqlx migrate run
-
-# (Interactively) remove some or all migration files
-migrate-clean:
-	rm -i migrations/*
-
-# Drop, recreate, and run migrations on the DB
-db-reset:
-	sqlx database reset
+[confirm("Are you sure you want to apply all pending migrations?")]
+migrate: mg-validate
+	atlas migrate apply --url $DATABASE_URL
 
 ####################################################################################################
 # Miscellaneous

--- a/backend/migrations/atlas.sum
+++ b/backend/migrations/atlas.sum
@@ -1,0 +1,5 @@
+h1:M2Ikjp6ZqYL/eI+viMc1t0gbGH6TrBsYMlR68WHqh1A=
+20250928210912_create_non_empty_text_domain.sql h1:xGIHmMDa9ftAsOAzZiHQSiotowCFwckLID9jnDeYDB8=
+20250928211244_create_users_table.sql h1:t5CjK2kBSqFNzIqWgspHlojijqxe3d81XlXYZyyuN64=
+20250928211253_create_friendship_table.sql h1:7snbY7QMeEX9xMnA+VQ6BXuTuyfeNzB6b2EQu/u6Wz0=
+20250928211258_create_post_table.sql h1:0QGdiYxS2Cddu+laMeEqyf+ssjt9s+9cqWTUfefr6L0=

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,45 @@
+-- Reusable type for non-empty text columns
+CREATE DOMAIN non_empty_text AS TEXT
+    CONSTRAINT text_non_empty CHECK (VALUE ~ '\S'); -- At least one non-whitespace character
+
+CREATE TABLE users (
+    id            INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name          non_empty_text NOT NULL,
+    email         non_empty_text NOT NULL CONSTRAINT users_email_unique UNIQUE,
+    username      non_empty_text NOT NULL
+                      CONSTRAINT users_username_chars CHECK (username ~ '^[A-Za-z0-9_-]+$')
+                      CONSTRAINT users_username_unique UNIQUE,
+    password_hash non_empty_text NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE friendship (
+    -- The IDs of the two users, always ordered
+    lesser_id        INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    greater_id       INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- Whether the user with the lesser ID is the one who initiated the request
+    lesser_requested BOOL NOT NULL,
+    requested_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    confirmed_at     TIMESTAMPTZ,
+    PRIMARY KEY (lesser_id, greater_id),
+    CONSTRAINT friendship_id_ordering CHECK (lesser_id < greater_id)
+);
+
+CREATE TABLE post (
+    id          INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    author_id   INT REFERENCES users(id) ON DELETE SET NULL,
+    parent_id   INT REFERENCES post(id) ON DELETE RESTRICT, -- Rows should only be soft deleted
+    body        non_empty_text,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    edited_at   TIMESTAMPTZ,
+    archived_at TIMESTAMPTZ,
+    deleted_at  TIMESTAMPTZ,
+    -- Enforce one child post per user per parent post
+    CONSTRAINT post_author_parent_unique UNIQUE (author_id, parent_id)
+);
+
+-- Enforce that only one post can have a NULL parent_id
+CREATE UNIQUE INDEX one_root_post
+    ON post ((true))
+    WHERE parent_id IS NULL;
+


### PR DESCRIPTION
Resolves #17 

As is explained in more detail in #17, this PR sets up the CLI tool Atlas to handle migrations for the project. Moving forward, the master `schema.sql` can be edited whenever a change needs to be made, and following the commands documented in the backend `justfile`, Atlas will generate the appropriate migration. This also allows Atlas to completely replace the functionality that the SQLx CLI was previously performing, meaning the SQLx CLI is no longer required. (SQLx is still the crate used to interact with the database from the Rust code.) 