### PR TITLE
Lock read row for transactions that read then write

### DIFF
--- a/backend/src/app_services/mutate_friendship_by_username_svc.rs
+++ b/backend/src/app_services/mutate_friendship_by_username_svc.rs
@@ -40,10 +40,11 @@ where
         // Find the recipient's ID and create an ID pair
         let recipient_id = self
             .user_repo
-            .get_by_username(tx.exec(), recipient_username)
+            .get_by_username_exclusive(tx.exec(), recipient_username)
             .await?
             .ok_or(FriendshipError::NonexistentUser)?
             .id;
+
         let ids = UserIdPair::new(sender_id, recipient_id)?;
 
         // Determine the pair's current status
@@ -94,7 +95,7 @@ mod tests {
             let ids = UserIdPair::new(my_id, my_friend.id).unwrap();
 
             let mock_user_repo = MockUserRepo {
-                get_by_username: Some(Box::new(move |passed_username| {
+                get_by_username_exclusive: Some(Box::new(move |passed_username| {
                     assert_eq!(my_friend_username_clone, passed_username);
                     Ok(Some(my_friend_clone.clone()))
                 })),
@@ -130,7 +131,7 @@ mod tests {
             let ids = UserIdPair::new(my_id, desired_friend.id).unwrap();
 
             let mock_user_repo = MockUserRepo {
-                get_by_username: Some(Box::new(move |passed_username| {
+                get_by_username_exclusive: Some(Box::new(move |passed_username| {
                     assert_eq!(desired_friend_username_clone, passed_username);
                     Ok(Some(desired_friend_clone.clone()))
                 })),
@@ -166,7 +167,7 @@ mod tests {
             let ids = UserIdPair::new(my_id, added_me.id).unwrap();
 
             let mock_user_repo = MockUserRepo {
-                get_by_username: Some(Box::new(move |passed_username| {
+                get_by_username_exclusive: Some(Box::new(move |passed_username| {
                     assert_eq!(added_me_username_clone, passed_username);
                     Ok(Some(added_me_clone.clone()))
                 })),
@@ -206,7 +207,7 @@ mod tests {
             let ids = UserIdPair::new(my_id, does_not_know_me.id).unwrap();
 
             let mock_user_svc = MockUserRepo {
-                get_by_username: Some(Box::new(move |passed_username| {
+                get_by_username_exclusive: Some(Box::new(move |passed_username| {
                     assert_eq!(does_not_know_me_username_clone, passed_username);
                     Ok(Some(does_not_know_me_clone.clone()))
                 })),

--- a/backend/src/domain/post.rs
+++ b/backend/src/domain/post.rs
@@ -25,7 +25,9 @@ pub trait PostRepo: Send + Sync {
         body: &str,
     ) -> Result<(), RepoError>;
 
-    async fn get_by_id(
+    /// Fetches a post by ID, blocking concurrent writes to the same post until the surrounding
+    /// transaction completes.
+    async fn get_by_id_exclusive(
         &self,
         exec: impl PgExecutor<'_>,
         id: i32,

--- a/backend/src/domain/post/service.rs
+++ b/backend/src/domain/post/service.rs
@@ -30,7 +30,7 @@ where
 
         let parent = self
             .repo
-            .get_by_id(tx.exec(), parent_id)
+            .get_by_id_exclusive(tx.exec(), parent_id)
             .await?
             .ok_or(PostError::NotFound)?;
 
@@ -76,7 +76,7 @@ mod tests {
         let parent_post_id = parent_post.as_ref().map_or(543, |post| post.id);
 
         let mock_repo = MockPostRepo {
-            get_by_id: Some(Box::new(move |passed_id| {
+            get_by_id_exclusive: Some(Box::new(move |passed_id| {
                 assert_eq!(parent_post_id, passed_id);
                 Ok(parent_post.clone())
             })),
@@ -140,7 +140,7 @@ mod tests {
         let new_post_body = "This is a new post that should work";
 
         let mock_repo = MockPostRepo {
-            get_by_id: Some(Box::new(move |passed_id| {
+            get_by_id_exclusive: Some(Box::new(move |passed_id| {
                 assert_eq!(parent_post_id, passed_id);
                 Ok(Some(parent_post.clone()))
             })),
@@ -199,7 +199,7 @@ mod tests {
         .enumerate()
         {
             let mock_post_repo = MockPostRepo {
-                get_by_id: Some(Box::new(move |passed_id| {
+                get_by_id_exclusive: Some(Box::new(move |passed_id| {
                     assert_eq!(parent_ids[i], passed_id);
                     // Alternating between the first and second dummy posts because the third is
                     // marked as deleted, which correctly causes a different error

--- a/backend/src/domain/user.rs
+++ b/backend/src/domain/user.rs
@@ -24,7 +24,9 @@ pub trait UserRepo: Send + Sync {
         email: &str,
     ) -> Result<Option<User>, RepoError>;
 
-    async fn get_by_username(
+    /// Fetches a user by username, blocking concurrent writes to the same user until the
+    /// surrounding transaction completes.
+    async fn get_by_username_exclusive(
         &self,
         exec: impl PgExecutor<'_>,
         username: &str,

--- a/backend/src/test_utils/mock_repos.rs
+++ b/backend/src/test_utils/mock_repos.rs
@@ -18,7 +18,8 @@ pub struct MockUserRepo {
     pub insert_new: Option<Box<dyn Fn(&NewUser) -> Result<User, RepoError> + Send + Sync>>,
     pub get_by_id: Option<Box<dyn Fn(i32) -> Result<Option<User>, RepoError> + Send + Sync>>,
     pub get_by_email: Option<Box<dyn Fn(&str) -> Result<Option<User>, RepoError> + Send + Sync>>,
-    pub get_by_username: Option<Box<dyn Fn(&str) -> Result<Option<User>, RepoError> + Send + Sync>>,
+    pub get_by_username_exclusive:
+        Option<Box<dyn Fn(&str) -> Result<Option<User>, RepoError> + Send + Sync>>,
 }
 
 #[async_trait::async_trait]
@@ -44,12 +45,12 @@ impl UserRepo for MockUserRepo {
     ) -> Result<Option<User>, RepoError> {
         (self.get_by_email.as_ref().unwrap())(email)
     }
-    async fn get_by_username(
+    async fn get_by_username_exclusive(
         &self,
         _exec: impl PgExecutor<'_>,
         username: &str,
     ) -> Result<Option<User>, RepoError> {
-        (self.get_by_username.as_ref().unwrap())(username)
+        (self.get_by_username_exclusive.as_ref().unwrap())(username)
     }
 }
 
@@ -94,7 +95,8 @@ impl FriendshipRepo for MockFriendshipRepo {
 #[derive(Default)]
 pub struct MockPostRepo {
     pub insert_new: Option<Box<dyn Fn(i32, i32, &str) -> Result<(), RepoError> + Send + Sync>>,
-    pub get_by_id: Option<Box<dyn Fn(i32) -> Result<Option<Post>, RepoError> + Send + Sync>>,
+    pub get_by_id_exclusive:
+        Option<Box<dyn Fn(i32) -> Result<Option<Post>, RepoError> + Send + Sync>>,
 }
 
 #[async_trait::async_trait]
@@ -109,11 +111,11 @@ impl PostRepo for MockPostRepo {
         (self.insert_new.as_ref().unwrap())(author_id, parent_id, body)
     }
 
-    async fn get_by_id(
+    async fn get_by_id_exclusive(
         &self,
         _exec: impl PgExecutor<'_>,
         id: i32,
     ) -> Result<Option<Post>, RepoError> {
-        (self.get_by_id.as_ref().unwrap())(id)
+        (self.get_by_id_exclusive.as_ref().unwrap())(id)
     }
 }


### PR DESCRIPTION
Resolves #21 

This PR ensures that in transactions that involve a read and then a write, the read row is not concurrently modified by another writer. This involved adding `FOR UPDATE` in the relevant SQL queries and appending `_exclusive` to function names for clarity.